### PR TITLE
Add large-item.js for creating large-ish test items

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ MW_SERVER=http://default.web.mw.localhost:8080/ MW_SCRIPT_PATH=/mediawiki docker
 
 * `all-property-datatypes.js` - creates a Property for every datatype supported by the Wikibase
 * `item-with-all-statements.js` - creates an Item with statements for ~~every supported datatype~~ datatypes string and time (but in the future it'll hopefully support all of them)
+* `large-item.js` - creates a large Item with many strings and external identifier statements. Append `--random-label` (after the `--script`/`-s` flag), to randomize the label, so that multiple items can be created.

--- a/entityTemplates/propertyWithDatatype.js
+++ b/entityTemplates/propertyWithDatatype.js
@@ -1,10 +1,10 @@
 import buildPropertySampleLabelForDatatype from '../src/buildPropertySampleLabelForDatatype.js'
 
-export default function propertyWithDatatype( datatype ) {
+export default function propertyWithDatatype( datatype, index = null ) {
     return {
         datatype,
         labels: {
-            en: { language: 'en', value: buildPropertySampleLabelForDatatype( datatype ) },
+            en: { language: 'en', value: buildPropertySampleLabelForDatatype( datatype, index ) },
         },
     }
 }

--- a/index.js
+++ b/index.js
@@ -82,13 +82,13 @@ class ApiClient {
 		return request;
 	}
 
-	async findOrCreatePropertyByDataType( datatype ){
-		const label = buildPropertySampleLabelForDatatype( datatype )
-		const propertyId = await this._findPropertyByLabel( label )
+	async findOrCreatePropertyByDataType( datatype, index = null ) {
+		const label = buildPropertySampleLabelForDatatype( datatype, index );
+		const propertyId = await this._findPropertyByLabel( label );
 		if ( propertyId !== null ) {
-			return propertyId
+			return propertyId;
 		} else {
-			return await this.createProperty( propertyWithDatatype( datatype ) )
+			return await this.createProperty( propertyWithDatatype( datatype, index ) );
 		}
 	}
 

--- a/large-item.js
+++ b/large-item.js
@@ -1,0 +1,65 @@
+import meow from 'meow';
+
+async function makeEntitySerialization( apiClient, statements, labelSuffix ) {
+    return {
+        labels: {
+            en: {
+                language: 'en', value: 'Large test item' + labelSuffix,
+            },
+        },
+        descriptions: {
+            en: {
+                language: 'en', value: 'a large test item created by wikibase-seed-data large-item.js',
+            },
+        },
+        claims: ( await Promise.all( statements.map( async ( [ statementsByProperty ] ) => {
+            const datatype = statementsByProperty.type;
+            const propertyIndex = statementsByProperty.index;
+            const propertyId = await apiClient.findOrCreatePropertyByDataType( datatype, propertyIndex );
+            if( propertyId ) {
+                return statementsByProperty.values.map( value => {
+                    return {
+                        mainsnak: {
+                            snaktype: 'value',
+                            property: propertyId,
+                            datavalue: value,
+                        },
+                        type: 'statement',
+                        rank: 'normal',
+                    };
+                } );
+            } else {
+                console.log(
+                    'Skipped creating a statement for datatype ' + datatype + ' with index ' + propertyIndex
+                );
+                return null;
+            }
+        } ).filter( s => s ) ) ).flatMap( s => s ),
+    };
+}
+
+export default async function( apiClient ) {
+    const cli = meow();
+    const stringValue = {
+        value: 'something',
+        type: 'string'
+    };
+
+    let statements = [];
+    // Create 60 string statements (two per property id)
+    for ( let i = 0; i < 30; i++ ) {
+        statements.push( [ { type: 'string', index: i, values: [ stringValue, stringValue ] } ] );
+    }
+    // Create 20 external-id statements (one per property id)
+    for ( let i = 0; i < 20; i++ ) {
+        statements.push( [ { type: 'external-id', index: i, values: [ stringValue ] } ] );
+    }
+    let labelSuffix = '';
+    if ( cli.flags.randomLabel ) {
+        labelSuffix = ' - ' + Math.random().toString().substring( 2 );
+    }
+
+    const entitySerialization = await makeEntitySerialization( apiClient, statements, labelSuffix );
+    const itemId = await apiClient.createItem( entitySerialization );
+    console.log( itemId );
+}

--- a/src/buildPropertySampleLabelForDatatype.js
+++ b/src/buildPropertySampleLabelForDatatype.js
@@ -1,3 +1,9 @@
-export default function ( datatype ){
-    return `${ datatype } property`
+export default function ( datatype, index = null ){
+	const ret = `${ datatype } property`;
+
+	if ( Number.isInteger( index ) ) {
+		return ret + ` No. ${ index }`;
+	} else {
+		return ret;
+	}
 }


### PR DESCRIPTION
Creates an item that has 60 string statements (two per property id) and 20 external-id statements (one per property id).